### PR TITLE
Fix shared examples to conform to rspec behavior

### DIFF
--- a/lib/motion-spec/context.rb
+++ b/lib/motion-spec/context.rb
@@ -53,8 +53,16 @@ module MotionSpec
       @after << block
     end
 
-    def behaves_like(*names)
-      names.each { |name| instance_eval(&Shared[name]) }
+    def it_behaves_like(name, &block)
+      describe("behaves like #{name}") do
+        include_examples(name)
+        instance_eval(&block) if block_given?
+      end
+    end
+    alias_method :behaves_like, :it_behaves_like
+
+    def include_examples(name)
+      instance_eval(&Shared[name])
     end
 
     def it(description, &block)

--- a/spec/motion-spec/bacon_spec.rb
+++ b/spec/motion-spec/bacon_spec.rb
@@ -313,20 +313,49 @@ shared 'another shared context' do
   end
 end
 
-describe 'shared/behaves_like' do
-  behaves_like 'a shared context'
+shared 'shared behavior with before' do
+  before { @shared_before = 'foo' }
+end
+
+describe 'it_behaves_like' do
+  it_behaves_like 'a shared context'
 
   ctx = self
   it 'raises NameError when the context is not found' do
     proc { ctx.behaves_like 'whoops' }.should.raise NameError
   end
 
-  behaves_like 'a shared context'
+  it_behaves_like 'a shared context'
 
-  before {
-    @magic = 42
-  }
-  behaves_like 'another shared context'
+  before { @magic = 42 }
+  it_behaves_like 'another shared context'
+
+  context 'isolates instance variables' do
+    it_behaves_like 'shared behavior with before' do
+      it 'runs within context of shared block' do
+        @shared_before.should.eq 'foo'
+      end
+    end
+
+    it 'does not leak instance variables' do
+      @shared_before.should.eq nil
+    end
+  end
+end
+
+describe 'include_examples' do
+  include_examples 'a shared context'
+
+  before { @magic = 42 }
+  include_examples 'another shared context'
+
+  context 'sets instance variables in parent scope' do
+    include_examples 'shared behavior with before'
+
+    it 'adds instance variables' do
+      @shared_before.should.eq 'foo'
+    end
+  end
 end
 
 describe 'Methods' do

--- a/spec/motion-spec/mac_bacon_spec.rb
+++ b/spec/motion-spec/mac_bacon_spec.rb
@@ -136,7 +136,7 @@ describe 'NSRunloop aware Bacon' do
           end
         end
 
-        behaves_like 'waiting in before/after filters'
+        include_examples 'waiting in before/after filters'
       end
 
       describe 'and without explicit time' do
@@ -162,7 +162,7 @@ describe 'NSRunloop aware Bacon' do
           end
         end
 
-        behaves_like 'waiting in before/after filters'
+        include_examples 'waiting in before/after filters'
       end
     end
 
@@ -194,7 +194,7 @@ describe 'NSRunloop aware Bacon' do
         @observable.an_attribute = 'changed'
       end
 
-      behaves_like 'waiting in before/after filters'
+      include_examples 'waiting in before/after filters'
     end
   end
 end


### PR DESCRIPTION
A few changes to make shared examples behave like they do in rspec:
- Rename `behaves_like` to `it_behaves_like`. `behaves_like` is still kept as an alias.
- `it_behaves_like` now includes the examples (and before/after) in a nested context. This allows reusing examples/contexts without leaking variables into the parent context.
- `includes_examples` will include examples (and before/after) in the current context.
