### PR TITLE
Nested examples should show as nested in output

### DIFF
--- a/lib/motion-spec/context.rb
+++ b/lib/motion-spec/context.rb
@@ -28,7 +28,9 @@ module MotionSpec
         @specifications.each(&:run)
       else
         spec = current_specification
-        return spec.performSelector('run', withObject: nil, afterDelay: 0) if spec
+        if spec
+          return spec.performSelector('run', withObject: nil, afterDelay: 0)
+        end
       end
 
       MotionSpec.context_did_finish(self)
@@ -84,12 +86,12 @@ module MotionSpec
     end
 
     def describe(*args, &block)
-      context = MotionSpec::Context.new("#{@name} #{args.join(' ')}", @before, @after, &block)
+      new_context = self.class.new(args.join(' '), @before, @after, &block)
 
       # FIXME: fix RM-879 and RM-806
-      build_ios_parent_context(context) unless Platform.android?
+      build_ios_parent_context(new_context) unless Platform.android?
 
-      context
+      new_context
     end
     alias_method :context, :describe
 

--- a/lib/motion-spec/context_helper/should.rb
+++ b/lib/motion-spec/context_helper/should.rb
@@ -3,7 +3,9 @@ module MotionSpec
   module ContextHelper
     module Should
       def should(*args, &block)
-        return it('should ' + args.first, &block) if Counter[:depth] == 0
+        if Counter[:context_depth] == 0
+          return it('should ' + args.first, &block)
+        end
 
         super(*args, &block)
       end

--- a/lib/motion-spec/matcher/raise_error.rb
+++ b/lib/motion-spec/matcher/raise_error.rb
@@ -4,7 +4,7 @@ module MotionSpec
     class RaiseError
       def initialize(error_class = Exception, message = '')
         @error_class = error_class.is_a?(Class) ? error_class : Exception
-        @error_message = (error_class.is_a?(String) || error_class.is_a?(Regexp)) ? error_class : message
+        @error_message = exception_matcher?(error_class) ? error_class : message
       end
 
       def matches?(_value, &block)
@@ -15,21 +15,24 @@ module MotionSpec
         exception_matches(e)
       end
 
+      def exception_matcher?(error_class)
+        error_class.is_a?(String) || error_class.is_a?(Regexp)
+      end
+
       def exception_matches(exception)
         return false unless exception.is_a?(@error_class)
 
-        is_match = case @error_message
-                   when String
-                     exception.message.include?(@error_message)
-                   when Regexp
-                     @error_message.match(exception.message)
-                   else
-                     false
-                    end
+        is_match =
+          case @error_message
+          when String
+            exception.message.include?(@error_message)
+          when Regexp
+            @error_message.match(exception.message)
+          else
+            false
+          end
 
-        return false unless is_match
-
-        true
+        is_match ? true : false
       end
 
       def fail!(_subject, negated)

--- a/lib/motion-spec/output/spec_dox.rb
+++ b/lib/motion-spec/output/spec_dox.rb
@@ -2,7 +2,7 @@
 module MotionSpec
   module SpecDoxOutput
     def handle_specification_begin(name)
-      puts spaces + name
+      puts "#{spaces}#{name}"
     end
 
     def handle_specification_end
@@ -24,6 +24,7 @@ module MotionSpec
     end
 
     def spaces
+      return if Counter[:context_depth] < 1
       '  ' * (Counter[:context_depth] - 1)
     end
   end

--- a/lib/motion-spec/should.rb
+++ b/lib/motion-spec/should.rb
@@ -40,7 +40,7 @@ module MotionSpec
 
       result = yield(@object, *args)
 
-      if Counter[:depth] > 0
+      if Counter[:context_depth] > 0
         Counter[:requirements] += 1
         flunk(description) unless @negated ^ result
         result

--- a/lib/motion-spec/specification.rb
+++ b/lib/motion-spec/specification.rb
@@ -46,7 +46,7 @@ module MotionSpec
 
     def run
       MotionSpec.handle_requirement_begin(@description)
-      Counter[:depth] += 1
+      Counter[:context_depth] += 1
       run_before_filters
       @number_of_requirements_before = Counter[:requirements]
       run_spec_block unless postponed?
@@ -173,7 +173,7 @@ module MotionSpec
 
     def exit_spec
       cancel_scheduled_requests!
-      Counter[:depth] -= 1
+      Counter[:context_depth] -= 1
       MotionSpec.handle_requirement_end(@error)
       @context.specification_did_finish(self)
     end

--- a/spec/motion-spec/bacon_spec.rb
+++ b/spec/motion-spec/bacon_spec.rb
@@ -278,4 +278,17 @@ describe 'MotionSpec' do
     it('works when referenced by name') { expect(named).to eq 42 }
     it('works when implied') { is_expected.to eq 42 }
   end
+
+  it 'works with namespaced modules' do
+    check(Kernel.send(:describe, MotionSpec::Context) {}, 'MotionSpec::Context')
+  end
+
+  it 'works with multiple arguments' do
+    check(Kernel.send(:describe, MotionSpec::Context, :empty) {}, 'MotionSpec::Context empty')
+  end
+
+  it 'prefixes the name of a nested context spaces based on nesting depth' do
+    check(describe('are nested') {}, 'are nested')
+    # check(describe('are nested') {}, '  are nested')
+  end
 end


### PR DESCRIPTION
Currently the `:context_depth` and `:depth` are disjoint (for no apparent reason) and specs don't nest when printed out, e.g.

``` bash
MotionSpec
  - has should.satisfy
  - has should.equal
  - has should.raise
  ...
  before/after
    - runs in the right order
    - does not run from lower level
```
