### PR TITLE
Implement let/subject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,12 @@ Metrics/ParameterLists:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'
   Enabled: false
 
+Style/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+    - leading
+    - trailing
+
 Style/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
@@ -56,6 +62,12 @@ Style/IndentationWidth:
 
 Style/MethodName:
   Enabled: false
+
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+    - aligned
+    - indented
 
 Style/StringLiterals:
   Description: Checks if uses of quotes match the configured preference.

--- a/lib/motion-spec/context_helper/memoized_helpers.rb
+++ b/lib/motion-spec/context_helper/memoized_helpers.rb
@@ -1,0 +1,50 @@
+module MotionSpec
+  module ContextHelper
+    module MemoizedHelpers
+      attr_accessor :__memoized
+
+      def let(name, &block)
+        raise '#let or #subject called without a block' unless block_given?
+
+        (class << self; self; end).class_eval do
+          define_method(name) do
+            self.__memoized ||= {}
+            __memoized.fetch(name) { __memoized[name] = block.call }
+          end
+        end
+
+        # The way that nested contexts are implemented requires us to manually
+        # reset any memoized values after each spec via an 'after'.
+        after { reset_memoized }
+      end
+
+      def let!(name, &block)
+        let(name, &block)
+        before { __send__(name) }
+      end
+
+      def subject(name = nil, &block)
+        if name
+          let(name, &block)
+          alias_method :subject, name
+        else
+          let(:subject, &block)
+        end
+      end
+
+      def subject!(name = nil, &block)
+        subject(name, &block)
+        before { subject }
+      end
+
+      def is_expected
+        expect(subject)
+      end
+
+      def reset_memoized
+        @__memoized = nil
+        parent_context.reset_memoized if respond_to?(:parent_context)
+      end
+    end
+  end
+end

--- a/lib/motion-spec/context_helper/memoized_helpers.rb
+++ b/lib/motion-spec/context_helper/memoized_helpers.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 module MotionSpec
   module ContextHelper
     module MemoizedHelpers
@@ -37,7 +38,7 @@ module MotionSpec
         before { subject }
       end
 
-      def is_expected
+      def is_expected # rubocop:disable Style/PredicateName
         expect(subject)
       end
 

--- a/spec/motion-spec/bacon_spec.rb
+++ b/spec/motion-spec/bacon_spec.rb
@@ -185,4 +185,84 @@ describe 'MotionSpec' do
       check(describe('are nested') {}, 'MotionSpec describe arguments are nested')
     end
   end
+
+  describe '#let' do
+    let(:foo) { 5 }
+    let(:foo_plus_1) { foo + 1 }
+
+    it('works') { foo.should.eq(5) }
+    it('works for lets referencing other lets') { foo_plus_1.should.eq(6) }
+
+    context 'in sub-contexts' do
+      let(:bar) { foo + 2 }
+
+      it('works') { foo.should.eq(5) }
+      it('works') { bar.should.eq(7) }
+    end
+
+    # 'bar' was defined in a different context so should not have leaked into
+    # this context.
+    context 'does not leak variables' do
+      it('works') { proc { bar }.should.raise(NameError) }
+    end
+
+    context 'when redefining existing variable' do
+      let(:foo) { 'hey' }
+
+      it('works') { foo.should.eq('hey') }
+    end
+  end
+
+  describe '#let!' do
+    def incremet_by_one
+      @state ||= 0
+      @state += 1
+    end
+
+    let(:foo) { incremet_by_one }
+    let(:bar) { incremet_by_one }
+
+    context 'without bang' do
+      before do
+        bar
+        foo
+      end
+
+      it 'initializes in order of use' do
+        expect(foo).to eq(bar + 1)
+      end
+    end
+
+    context 'with bang' do
+      let!(:foo) { incremet_by_one }
+
+      before do
+        bar
+        foo
+      end
+
+      it 'initializes bangs first' do
+        bar.should.eq(foo + 1)
+      end
+    end
+  end
+
+  # Note: This works in rspec but does not work here due to differences in how
+  # nested contexts work, namely the fact that in rspec each example/spec is
+  # it's own subclass.
+  # context 'referencing nested variable' do
+  #   let(:foo) { bar + 1 }
+
+  #   context 'bar' do
+  #     let(:bar) { 5 }
+
+  #     it('works') { expect(foo).to eq(6) }
+  #   end
+  # end
+
+  describe '#is_expected' do
+    subject { 5 }
+
+    it('works') { is_expected.to eq(5) }
+  end
 end


### PR DESCRIPTION
This isn't a 100% 1-1 with rspec but it's as close as we're going to get without a major refactor. The big issue is that rspec implements each example/spec as it's own subclass of the parent contexts which makes it easier to prevent things leaking into other examples.
