### PR TITLE
Initialize Bacon and Bacon::Context

### DIFF
--- a/lib/motion-spec/extensions/bacon.rb
+++ b/lib/motion-spec/extensions/bacon.rb
@@ -1,0 +1,9 @@
+# -*- encoding : utf-8 -*-
+
+# There are gems (e.g. motion-stump) that rely on Bacon or some of its
+# sub-modules to exist so they can extend them. This file ensures that
+# MotionSpec can be used alongside those gems but may break some functionality.
+module Bacon
+  class Context < MotionSpec::Context
+  end
+end


### PR DESCRIPTION
There are gems (e.g. motion-stump) that rely on Bacon or some of its sub-modules to exist so they can extend them. This initializes Bacon and Bacon::Context to ensure that MotionSpec can be used alongside those gems but it may break some functionality.
