### PR TITLE
Absorb motion-stump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #!/usr/bin/env rake
-$:.unshift('/Library/RubyMotion/lib')
+$LOAD_PATH.unshift('/Library/RubyMotion/lib')
 require 'motion/project/template/ios'
 require 'bundler/gem_tasks'
 Bundler.setup

--- a/app/app_delegate.rb
+++ b/app/app_delegate.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 class AppDelegate
-  def application(application, didFinishLaunchingWithOptions:launchOptions)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def application(_application, didFinishLaunchingWithOptions:launchOptions)
     true
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/lib/motion-spec.rb
+++ b/lib/motion-spec.rb
@@ -45,6 +45,9 @@ require_lib_files('matcher/*')
 # Monkeypatch core objects to respond to test methods
 require_lib_files('extensions/*')
 
+# Allow method mocks and stubs
+require_lib_files('mock/*')
+
 # FIXME : Need better detection for iPhone Simulator
 if defined?(UIDevice) &&
   UIDevice.respond_to?('currentDevice') &&

--- a/lib/motion-spec.rb
+++ b/lib/motion-spec.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 unless defined?(Motion::Project::Config)
-  raise 'The MotionSpec gem must be required within a RubyMotion project Rakefile.'
+  fail 'The MotionSpec gem must be required within a RubyMotion project Rakefile.'
 end
 
 require 'motion-require'
@@ -50,8 +50,8 @@ require_lib_files('mock/*')
 
 # FIXME : Need better detection for iPhone Simulator
 if defined?(UIDevice) &&
-  UIDevice.respond_to?('currentDevice') &&
-  !UIDevice.currentDevice.name =~ /(iPhone|iPad) Simulator/
+    UIDevice.respond_to?('currentDevice') &&
+    !UIDevice.currentDevice.name =~ /(iPhone|iPad) Simulator/
 
   module Kernel
     def puts(*args)
@@ -77,8 +77,8 @@ module Motion
             # NOTE: This line is commented out to avoid loading Bacon.
             ( # ['spec.rb'] +
             Dir.glob(File.join('spec', 'helpers', '*.rb')) +
-            Dir.glob(File.join('project', 'template', App.template.to_s, 'spec-helpers', '*.rb'))).
-              map { |x| File.expand_path(x) }
+            Dir.glob(File.join('project', 'template', App.template.to_s, 'spec-helpers', '*.rb')))
+              .map { |x| File.expand_path(x) }
           end
         end
       end

--- a/lib/motion-spec/context.rb
+++ b/lib/motion-spec/context.rb
@@ -76,6 +76,8 @@ module MotionSpec
 
       Counter[:specifications] += 1
 
+      @after << proc { verify_mocks_were_called }
+
       @specifications << Specification.new(
         self, description, block, @before, @after
       )
@@ -155,6 +157,20 @@ module MotionSpec
           parent_context.send(method_name, *args)
         end
       end
+    end
+
+    def mock_failures
+      MotionSpec::Mocks.failures
+    end
+
+    def verify_mocks_were_called
+      return unless mock_failures && !mock_failures.empty?
+
+      fails = mock_failures.map do |object, method|
+        "#{object.inspect} expected #{method}"
+      end
+
+      should.flunk "Unmet expectations: #{fails.join(', ')}"
     end
   end
 end

--- a/lib/motion-spec/context.rb
+++ b/lib/motion-spec/context.rb
@@ -38,7 +38,7 @@ module MotionSpec
       @specifications[@current_specification_index]
     end
 
-    def specification_did_finish(spec)
+    def specification_did_finish(_spec)
       return if Platform.android?
 
       if (@current_specification_index + 1) < @specifications.size

--- a/lib/motion-spec/context_helper/memoized_helpers.rb
+++ b/lib/motion-spec/context_helper/memoized_helpers.rb
@@ -5,7 +5,7 @@ module MotionSpec
       attr_accessor :__memoized
 
       def let(name, &block)
-        raise '#let or #subject called without a block' unless block_given?
+        fail '#let or #subject called without a block' unless block_given?
 
         (class << self; self; end).class_eval do
           define_method(name) do

--- a/lib/motion-spec/core.rb
+++ b/lib/motion-spec/core.rb
@@ -7,9 +7,9 @@ module MotionSpec
 
   Counter = Hash.new(0)
   ErrorLog = ''
-  Shared = Hash.new { |_, name|
-    raise NameError, "no such context: #{name.inspect}"
-  }
+  Shared = Hash.new do |_, name|
+    fail NameError, "no such context: #{name.inspect}"
+  end
 
   RestrictName    = //  unless defined? RestrictName
   RestrictContext = //  unless defined? RestrictContext
@@ -74,7 +74,7 @@ module MotionSpec
     @main_activity
   end
 
-  def self.context_did_finish(context)
+  def self.context_did_finish(_context)
     return if Platform.android?
 
     handle_specification_end

--- a/lib/motion-spec/expectation.rb
+++ b/lib/motion-spec/expectation.rb
@@ -22,7 +22,7 @@ module MotionSpec
     end
 
     def fail(matcher, negated)
-      raise matcher.fail!(@subject, negated, &@subject_block)
+      fail matcher.fail!(@subject, negated, &@subject_block)
     end
 
     def assert

--- a/lib/motion-spec/extensions/boolean.rb
+++ b/lib/motion-spec/extensions/boolean.rb
@@ -1,13 +1,22 @@
 # -*- encoding : utf-8 -*-
 class Object
-  def true?; false; end
-  def false?; false; end
+  def true?
+    false
+  end
+
+  def false?
+    false
+  end
 end
 
 class TrueClass
-  def true?; true; end
+  def true?
+    true
+  end
 end
 
 class FalseClass
-  def false?; true; end
+  def false?
+    true
+  end
 end

--- a/lib/motion-spec/extensions/numeric.rb
+++ b/lib/motion-spec/extensions/numeric.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
 class Numeric
   def close?(to, delta)
-    (to.to_f - self).abs <= delta.to_f rescue false
+    (to.to_f - self).abs <= delta.to_f
+  rescue
+    false
   end
 end

--- a/lib/motion-spec/extensions/proc.rb
+++ b/lib/motion-spec/extensions/proc.rb
@@ -9,10 +9,10 @@ class Proc
   end
 
   def throw?(sym)
-    catch(sym) {
+    catch(sym) do
       call
       return false
-    }
+    end
     true
   end
 

--- a/lib/motion-spec/matcher/be_false.rb
+++ b/lib/motion-spec/matcher/be_false.rb
@@ -8,7 +8,7 @@ module MotionSpec
 
       def fail!(subject, negated)
         message = FailMessageRenderer.message_for_be_false(negated, subject)
-        raise FailedExpectation.new(message)
+        fail FailedExpectation.new(message)
       end
     end
   end

--- a/lib/motion-spec/matcher/be_nil.rb
+++ b/lib/motion-spec/matcher/be_nil.rb
@@ -3,11 +3,11 @@ module MotionSpec
   module Matcher
     class BeNil
       def matches?(value)
-        value == nil
+        value.nil?
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_be_nil(negated, subject)
         )
       end

--- a/lib/motion-spec/matcher/be_true.rb
+++ b/lib/motion-spec/matcher/be_true.rb
@@ -7,7 +7,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_be_true(negated, subject)
         )
       end

--- a/lib/motion-spec/matcher/be_within.rb
+++ b/lib/motion-spec/matcher/be_within.rb
@@ -14,12 +14,12 @@ module MotionSpec
       end
 
       def matches?(subject)
-        raise InvalidMatcher.new(INVALID_MATCH_ERROR) unless @center_value
+        fail InvalidMatcher.new(INVALID_MATCH_ERROR) unless @center_value
         (subject - @center_value).abs <= @range
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_be_within(
             negated, subject, @range, @center_value
           )

--- a/lib/motion-spec/matcher/change.rb
+++ b/lib/motion-spec/matcher/change.rb
@@ -11,7 +11,7 @@ module MotionSpec
         self
       end
 
-      def matches?(subject, &expectation_block)
+      def matches?(_subject, &expectation_block)
         old_value = @change_block.call
         expectation_block.call
         new_value = @change_block.call
@@ -23,8 +23,8 @@ module MotionSpec
         end
       end
 
-      def fail!(subject, negated)
-        raise FailedExpectation.new(
+      def fail!(_subject, negated)
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_change(
             negated, @change_amount, @value_diff
           )

--- a/lib/motion-spec/matcher/end_with.rb
+++ b/lib/motion-spec/matcher/end_with.rb
@@ -11,7 +11,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_end_with(
             negated, subject, @end_string
           )

--- a/lib/motion-spec/matcher/have_generic.rb
+++ b/lib/motion-spec/matcher/have_generic.rb
@@ -12,7 +12,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_have_generic(
             negated, subject, @method_name, @args
           )

--- a/lib/motion-spec/matcher/have_items.rb
+++ b/lib/motion-spec/matcher/have_items.rb
@@ -18,7 +18,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_have_items(
             negated, subject, @number_of_items, subject.size, @key_type_name
           )

--- a/lib/motion-spec/matcher/include.rb
+++ b/lib/motion-spec/matcher/include.rb
@@ -11,7 +11,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_include(negated, subject, @values)
         )
       end

--- a/lib/motion-spec/matcher/match_array.rb
+++ b/lib/motion-spec/matcher/match_array.rb
@@ -17,7 +17,7 @@ module MotionSpec
       end
 
       def fail!(subject_array, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_match_array(
             negated, subject_array, @expected_array
           )

--- a/lib/motion-spec/matcher/raise_error.rb
+++ b/lib/motion-spec/matcher/raise_error.rb
@@ -7,7 +7,7 @@ module MotionSpec
         @error_message = (error_class.is_a?(String) || error_class.is_a?(Regexp)) ? error_class : message
       end
 
-      def matches?(value, &block)
+      def matches?(_value, &block)
         block.call
         false
       rescue Exception => e
@@ -19,12 +19,12 @@ module MotionSpec
         return false unless exception.is_a?(@error_class)
 
         is_match = case @error_message
-                    when String
-                      exception.message.include?(@error_message)
-                    when Regexp
-                      @error_message.match(exception.message)
-                    else
-                      false
+                   when String
+                     exception.message.include?(@error_message)
+                   when Regexp
+                     @error_message.match(exception.message)
+                   else
+                     false
                     end
 
         return false unless is_match
@@ -32,10 +32,10 @@ module MotionSpec
         true
       end
 
-      def fail!(subject, negated)
+      def fail!(_subject, negated)
         show_class = @error_class != Exception
         show_message = !@error_message.is_a?(String) || !@error_message.empty?
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_raise_error(
             negated, show_class, @error_class, show_message, @error_message,
             @rescued_exception

--- a/lib/motion-spec/matcher/respond_to.rb
+++ b/lib/motion-spec/matcher/respond_to.rb
@@ -29,7 +29,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_respond_to(
             negated, subject, @method_name, @number_of_args
           )

--- a/lib/motion-spec/matcher/satisfy.rb
+++ b/lib/motion-spec/matcher/satisfy.rb
@@ -10,8 +10,8 @@ module MotionSpec
         @condition_block.call(*values)
       end
 
-      def fail!(subject, negated)
-        raise FailedExpectation.new(
+      def fail!(_subject, negated)
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_satisfy(negated)
         )
       end

--- a/lib/motion-spec/matcher/single_method.rb
+++ b/lib/motion-spec/matcher/single_method.rb
@@ -12,7 +12,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(fail_message(subject, negated))
+        fail FailedExpectation.new(fail_message(subject, negated))
       end
 
       def fail_message(subject, negated = false)

--- a/lib/motion-spec/matcher/start_with.rb
+++ b/lib/motion-spec/matcher/start_with.rb
@@ -11,7 +11,7 @@ module MotionSpec
       end
 
       def fail!(subject, negated)
-        raise FailedExpectation.new(
+        fail FailedExpectation.new(
           FailMessageRenderer.message_for_start_with(
             negated, subject, @start_string
           )

--- a/lib/motion-spec/mock/method_bind_unbind.rb
+++ b/lib/motion-spec/mock/method_bind_unbind.rb
@@ -9,7 +9,7 @@ class Object
   end
 
   def meta_eval(&block)
-    metaclass.instance_eval &block
+    metaclass.instance_eval(&block)
   end
 
   # Adds methods to a metaclass

--- a/lib/motion-spec/mock/method_bind_unbind.rb
+++ b/lib/motion-spec/mock/method_bind_unbind.rb
@@ -1,0 +1,57 @@
+# -*- encoding : utf-8 -*-
+# The meta-programming that allows us to pop methods on and off for mocking
+class Object
+  # The hidden singleton lurks behind everyone
+  def metaclass
+    class << self
+      self
+    end
+  end
+
+  def meta_eval(&block)
+    metaclass.instance_eval &block
+  end
+
+  # Adds methods to a metaclass
+  def meta_def(name, &method_body)
+    meta_eval do
+      define_method(name) { |*args, &block| method_body.call(*args, &block) }
+    end
+  end
+
+  def safe_meta_def(name, &method_body)
+    metaclass.remember_original_method(name)
+    meta_def(name, &method_body)
+  end
+
+  # Defines an instance method within a class
+  def class_def(name, &block)
+    class_eval { define_method name, &block }
+  end
+
+  def reset(method_name)
+    metaclass.restore_original_method(method_name)
+  end
+
+  protected
+
+  def motion_spec_original_method_name(method_name)
+    "__original_#{method_name}".to_sym
+  end
+
+  def remember_original_method(method_name)
+    if method_defined?(method_name)
+      alias_method motion_spec_original_method_name(method_name), method_name
+    end
+    self
+  end
+
+  def restore_original_method(method_name)
+    original_method_name = motion_spec_original_method_name(method_name)
+    if method_defined?(original_method_name)
+      alias_method method_name, original_method_name
+      remove_method original_method_name
+    end
+    self
+  end
+end

--- a/lib/motion-spec/mock/mock.rb
+++ b/lib/motion-spec/mock/mock.rb
@@ -1,0 +1,63 @@
+# -*- encoding : utf-8 -*-
+class Object
+  # Create a mock method on an object.  A mock object will place an expectation
+  # on behavior and cause a test failure if it's not fulfilled.
+  #
+  # ==== Examples
+  #
+  #    my_string = "a wooden rabbit"
+  #    my_string.mock!(:retreat!, :return => "run away!  run away!")
+  #    my_string.mock!(:question, :return => "what is the airspeed velocity of an unladen sparrow?")
+  #
+  #    # test/your_test.rb
+  #    my_string.retreat!    # => "run away!  run away!"
+  #    # If we let the test case end at this point, it fails with:
+  #    # Unmet expectation: #<Sparrow:1ee7> expected question
+  #
+  def mock!(method, options = {}, &block)
+    MotionSpec::Mocks.add([self, method])
+
+    behavior =
+      if block_given?
+        lambda do |*args|
+          raise ArgumentError if block.arity >= 0 && args.length != block.arity
+
+          MotionSpec::Mocks.verify([self, method])
+          block.call(*args)
+        end
+      elsif !options[:yield].nil?
+        lambda do |*_args|
+          MotionSpec::Mocks.verify([self, method])
+          yield(options[:yield])
+        end
+      else
+        lambda do |*_args|
+          MotionSpec::Mocks.verify([self, method])
+          return options[:return]
+        end
+      end
+
+    safe_meta_def method, &behavior
+  end
+
+  def should_not_call(method)
+    safe_meta_def(method) do
+      should.flunk "Umet expectations: #{method} expected to not be called"
+    end
+  end
+end
+
+module Kernel
+  # Create a pure mock object rather than mocking specific methods on an object.
+  #
+  # ==== Examples
+  #
+  #     my_mock = mock(:thing, :return => "whee!")
+  #     my_mock.thing    # => "whee"
+  #
+  def mock(method, options = {}, &block)
+    mock_object = Object.new
+    mock_object.mock!(method, options, &block)
+    mock_object
+  end
+end

--- a/lib/motion-spec/mock/mock.rb
+++ b/lib/motion-spec/mock/mock.rb
@@ -20,7 +20,7 @@ class Object
     behavior =
       if block_given?
         lambda do |*args|
-          raise ArgumentError if block.arity >= 0 && args.length != block.arity
+          fail ArgumentError if block.arity >= 0 && args.length != block.arity
 
           MotionSpec::Mocks.verify([self, method])
           block.call(*args)

--- a/lib/motion-spec/mock/mocks.rb
+++ b/lib/motion-spec/mock/mocks.rb
@@ -1,0 +1,29 @@
+# -*- encoding : utf-8 -*-
+module MotionSpec
+  # A class to track the mocks and proxies that have been satisfied
+  class Mocks
+    class <<self
+      def size
+        @mocks ? 0 : @mocks.size
+      end
+
+      def add(mock)
+        @mocks ||= []
+        Counter[:requirements] += 1
+        @mocks << mock
+      end
+
+      def verify(mock)
+        @mocks.delete(mock)
+      end
+
+      def failures
+        @mocks
+      end
+
+      def clear!
+        @mocks = []
+      end
+    end
+  end
+end

--- a/lib/motion-spec/mock/proxy.rb
+++ b/lib/motion-spec/mock/proxy.rb
@@ -1,0 +1,115 @@
+# -*- encoding : utf-8 -*-
+class Object
+  # Creates a proxy method on an object.  In this setup, it places an expectation on an object (like a mock)
+  # but still calls the original method.  So if you want to make sure the method is called and still return
+  # its value, or simply want to invoke the side effects of a method and return a stubbed value, then you can
+  # do that.
+  #
+  # ==== Examples
+  #
+  #     class Parrot
+  #       def speak!
+  #         puts @words
+  #       end
+  #
+  #       def say_this(words)
+  #         @words = words
+  #         "I shall say #{words}!"
+  #       end
+  #     end
+  #
+  #     # => test/your_test.rb
+  #     sqawky = Parrot.new
+  #     sqawky.proxy!(:say_this)
+  #     # Proxy method still calls original method...
+  #     sqawky.say_this("hey")   # => "I shall say hey!"
+  #     sqawky.speak!            # => "hey"
+  #
+  #     sqawky.proxy!(:say_this, "herro!")
+  #     # Even though we return a stubbed value...
+  #     sqawky.say_this("these words")   # => "herro!"
+  #     # ...the side effects are still there.
+  #     sqawky.speak!                    # => "these words"
+  #
+  # TODO: This implementation is still very rough.  Needs refactoring and refining.  Won't
+  # work on ActiveRecord attributes, for example.
+  #
+  def proxy!(method, options = {}, &block)
+    MotionSpec::Mocks.add([self, method])
+
+    if respond_to?(method)
+      proxy_existing_method(method, options, &block)
+    else
+      proxy_missing_method(method, options, &block)
+    end
+  end
+
+  protected
+
+  def proxy_existing_method(method, options = {}, &_block)
+    method_alias = "__old_#{method}".to_sym
+
+    meta_eval { module_eval { alias_method method_alias, method } }
+
+    check_arity = proc do |args|
+      arity = method(method_alias.to_sym).arity
+
+      # Negative arity means some params are optional, so we check for the
+      # minimum required. Sadly, we can't tell what the maximum is.
+      has_mimimum_arguments =
+        if arity >= 0
+          args.length != arity
+        else
+          args.length < ~arity
+        end
+
+      raise ArgumentError unless has_mimimum_arguments
+    end
+
+    default_operation =
+      lambda do |*args|
+        check_arity.call(args)
+
+        MotionSpec::Mocks.verify([self, method])
+
+        if method(method_alias.to_sym).arity == 0
+          send(method_alias)
+        else
+          send(method_alias, *args)
+        end
+      end
+
+    behavior =
+      if options[:return]
+        lambda do |*args|
+          default_operation.call(*args)
+          return options[:return]
+        end
+      else
+        default_operation
+      end
+
+    meta_def method, &behavior
+  end
+
+  def proxy_missing_method(method, options = {}, &_block)
+    default_operation =
+      lambda do |*args|
+        MotionSpec::Mocks.verify([self, method])
+
+        method_missing(method, args)
+      end
+
+    behavior =
+      if options[:return]
+        lambda do |*args|
+          default_operation.call(*args)
+          return options[:return]
+        end
+      else
+        default_operation
+      end
+
+    meta_def method, &behavior
+  end
+end

--- a/lib/motion-spec/mock/proxy.rb
+++ b/lib/motion-spec/mock/proxy.rb
@@ -63,7 +63,7 @@ class Object
           args.length < ~arity
         end
 
-      raise ArgumentError unless has_mimimum_arguments
+      fail ArgumentError unless has_mimimum_arguments
     end
 
     default_operation =

--- a/lib/motion-spec/mock/stub.rb
+++ b/lib/motion-spec/mock/stub.rb
@@ -1,0 +1,37 @@
+# -*- encoding : utf-8 -*-
+class Object
+  # Create a stub method on an object.  Simply returns a value for a method call on
+  # an object.
+  #
+  # ==== Examples
+  #
+  #    my_string = "a wooden rabbit"
+  #    my_string.stub!(:retreat!, :return => "run away!  run away!")
+  #
+  #    # test/your_test.rb
+  #    my_string.retreat!    # => "run away!  run away!"
+  #
+  def stub!(method_name, options = {}, &stubbed)
+    MotionSpec::Stubs.add(self, method_name)
+
+    behavior = (block_given? ? stubbed : -> { return options[:return] })
+
+    safe_meta_def method_name, &behavior
+  end
+end
+
+module Kernel
+  # Create a pure stub object.
+  #
+  # ==== Examples
+  #
+  #     stubbalicious = stub(:failure, "wat u say?")
+  #     stubbalicious.failure     # => "wat u say?"
+  #
+  def stub(method, options = {}, &block)
+    stub_object = Object.new
+    stub_object.stub!(method, options, &block)
+
+    stub_object
+  end
+end

--- a/lib/motion-spec/mock/stubs.rb
+++ b/lib/motion-spec/mock/stubs.rb
@@ -1,0 +1,18 @@
+# -*- encoding : utf-8 -*-
+module MotionSpec
+  class Stubs
+    class << self
+      def add(object, method)
+        stubs << [object, method]
+      end
+
+      def stubs
+        @stubs ||= []
+      end
+
+      def clear!
+        stubs.each { |object, method| object.reset(method) }
+      end
+    end
+  end
+end

--- a/lib/motion-spec/output/ruby_mine.rb
+++ b/lib/motion-spec/output/ruby_mine.rb
@@ -26,7 +26,7 @@ module MotionSpec
     end
 
     def handle_requirement_end(error)
-      if !error.empty?
+      unless error.empty?
         puts "##teamcity[testFailed timestamp = '#{java_time}' message = '#{escape_message(error)}' name = '#{escape_message(@@description)}']\n\n"
       end
       duration = ((Time.now - @@started) * 1000).to_i
@@ -36,7 +36,7 @@ module MotionSpec
     def handle_summary
       print ErrorLog if Backtraces
       puts '%d specifications (%d requirements), %d failures, %d errors' %
-               Counter.values_at(:specifications, :requirements, :failed, :errors)
+        Counter.values_at(:specifications, :requirements, :failed, :errors)
     end
 
     def spaces

--- a/lib/motion-spec/should.rb
+++ b/lib/motion-spec/should.rb
@@ -31,7 +31,7 @@ module MotionSpec
     alias_method :a,  :be
     alias_method :an, :be
 
-    def satisfy(*args, &block)
+    def satisfy(*args, &_block)
       if args.size == 1 && String === args.first
         description = args.shift
       else
@@ -82,7 +82,7 @@ module MotionSpec
     end
 
     def flunk(reason = 'Flunked')
-      raise Error.new(:failed, reason)
+      fail Error.new(:failed, reason)
     end
   end
 end

--- a/lib/motion-spec/specification.rb
+++ b/lib/motion-spec/specification.rb
@@ -40,6 +40,8 @@ module MotionSpec
     def run_after_filters
       @ran_after_filters = true
       execute_block { @after_filters.each { |f| @context.instance_eval(&f) } }
+      Mocks.clear!
+      Stubs.clear!
     end
 
     def run

--- a/lib/motion-spec/specification.rb
+++ b/lib/motion-spec/specification.rb
@@ -68,7 +68,7 @@ module MotionSpec
     def postpone_block(timeout = 1, &block)
       # If an exception occurred, we definitely don't need to schedule any more blocks
       return if @exception_occurred
-      raise MULTIPLE_POSTPONES_ERROR_MESSAGE if @postponed_block
+      fail MULTIPLE_POSTPONES_ERROR_MESSAGE if @postponed_block
 
       @postponed_blocks_count += 1
       @postponed_block = block
@@ -86,7 +86,7 @@ module MotionSpec
     def postpone_block_until_change(object_to_observe, key_path, timeout = 1, &block)
       # If an exception occurred, we definitely don't need to schedule any more blocks
       return if @exception_occurred
-      raise MULTIPLE_POSTPONES_ERROR_MESSAGE if @postponed_block
+      fail MULTIPLE_POSTPONES_ERROR_MESSAGE if @postponed_block
 
       @postponed_blocks_count += 1
       @postponed_block = block
@@ -103,9 +103,11 @@ module MotionSpec
       postponed_change_block_timeout_exceeded
     end
 
-    def observeValueForKeyPath(key_path, ofObject:object, change:_, context:__)
+    # rubocop:disable Lint/UnusedMethodArgument
+    def observeValueForKeyPath(_key_path, ofObject:object, change:_, context:__)
       resume
     end
+    # rubocop:enable Lint/UnusedMethodArgument
 
     def postponed_change_block_timeout_exceeded
       remove_observer!
@@ -122,7 +124,7 @@ module MotionSpec
 
     def postponed_block_timeout_exceeded
       cancel_scheduled_requests!
-      execute_block { raise Error.new(:failed, "timeout exceeded: #{@context.name} - #{@description}") }
+      execute_block { fail Error.new(:failed, "timeout exceeded: #{@context.name} - #{@description}") }
       @postponed_blocks_count = 0
       finish_spec
     end
@@ -133,7 +135,8 @@ module MotionSpec
         NSObject.cancelPreviousPerformRequestsWithTarget(self, selector: 'postponed_change_block_timeout_exceeded', object: nil)
       end
       remove_observer!
-      block, @postponed_block = @postponed_block, nil
+      block = @postponed_block
+      @postponed_block = nil
       run_postponed_block(block)
     end
 
@@ -155,7 +158,7 @@ module MotionSpec
     def finish_spec
       if !@exception_occurred && Counter[:requirements] == @number_of_requirements_before
         # the specification did not contain any requirements, so it flunked
-        execute_block { raise Error.new(:missing, "empty specification: #{@context.name} #{@description}") }
+        execute_block { fail Error.new(:missing, "empty specification: #{@context.name} #{@description}") }
       end
       run_after_filters
       exit_spec unless postponed?
@@ -183,9 +186,9 @@ module MotionSpec
       if e.is_a?(Exception)
         ErrorLog << "#{e.class}: #{e.message}\n"
         lines = $DEBUG ? e.backtrace : e.backtrace.find_all { |line| line !~ /bin\/macbacon|\/mac_bacon\.rb:\d+/ }
-        lines.each_with_index { |line, i|
+        lines.each_with_index do |line, i|
           ErrorLog << "\t#{line}#{i == 0 ? ": #{@context.name} - #{@description}" : ''}\n"
-        }
+        end
         ErrorLog << "\n"
       else
         if defined?(NSException)

--- a/spec/motion-spec/matchers/be_generic_spec.rb
+++ b/spec/motion-spec/matchers/be_generic_spec.rb
@@ -17,12 +17,20 @@ describe 'Matcher::BeGeneric' do
   end
 
   it 'be_amazing passes when the value responds to amazing? and returns true' do
-    class TestClass; def amazing?; true; end; end
+    class TestClass
+      def amazing?
+        true
+      end
+    end
     expect(TestClass.new).to be_amazing
   end
 
   it 'be_amazing fails when the value responds to amazing? and returns false' do
-    class TestClass; def amazing?; false; end; end
+    class TestClass
+      def amazing?
+        false
+      end
+    end
     object = TestClass.new
     expect_failure("#{object.inspect} #amazing? expected to return true") { expect(object).to be_amazing }
   end

--- a/spec/motion-spec/matchers/change_spec.rb
+++ b/spec/motion-spec/matchers/change_spec.rb
@@ -34,7 +34,7 @@ describe 'Matcher::Change' do
   end
 
   context "when specified 'by'" do
-    it 'passes when changes are by the given amount'  do
+    it 'passes when changes are by the given amount' do
       expect do
         @test_object.add
         @test_object.add

--- a/spec/motion-spec/matchers/include_spec.rb
+++ b/spec/motion-spec/matchers/include_spec.rb
@@ -11,12 +11,20 @@ describe 'Matcher::Include' do
   end
 
   it 'include passes when an object responds true to include?' do
-    class TestClass; def include?(_); true; end; end
+    class TestClass
+      def include?(_)
+        true
+      end
+    end
     expect(TestClass.new).to include(3)
   end
 
   it 'include passes when an object responds false to include?' do
-    class TestClass; def include?(_); false; end; end
+    class TestClass
+      def include?(_)
+        false
+      end
+    end
     test_object = TestClass.new
     expect_failure("#{test_object.inspect} expected to include 3") do
       expect(test_object).to include(3)

--- a/spec/motion-spec/matchers/raise_error_spec.rb
+++ b/spec/motion-spec/matchers/raise_error_spec.rb
@@ -33,7 +33,7 @@ describe 'Matcher::RaiseError' do
   context 'with a string argument' do
     context 'raised message includes the string' do
       it 'passes' do
-        expect { raise 'one message' }.to raise_error('one message')
+        expect { fail 'one message' }.to raise_error('one message')
       end
     end
 
@@ -44,7 +44,7 @@ describe 'Matcher::RaiseError' do
           'but was #<RuntimeError: one message>'
 
         expect_failure(message) do
-          expect { raise 'one message' }.to raise_error('different')
+          expect { fail 'one message' }.to raise_error('different')
         end
       end
     end
@@ -53,7 +53,7 @@ describe 'Matcher::RaiseError' do
   context 'with a regex argument' do
     context 'raised message matches the regex' do
       it 'passes' do
-        expect { raise 'one message' }.to raise_error(/message/)
+        expect { fail 'one message' }.to raise_error(/message/)
       end
     end
 
@@ -64,7 +64,7 @@ describe 'Matcher::RaiseError' do
           "#{/different/.inspect} but was #<RuntimeError: one message>"
 
         expect_failure(message) do
-          expect { raise 'one message' }.to raise_error(/different/)
+          expect { fail 'one message' }.to raise_error(/different/)
         end
       end
     end
@@ -72,7 +72,7 @@ describe 'Matcher::RaiseError' do
 
   context 'with a class and string arguments' do
     it 'passes if the block raises an exception of the same class and includes the string in its message' do
-      expect { raise ArgumentError.new('with a message') }.to raise_error(ArgumentError, 'message')
+      expect { fail ArgumentError.new('with a message') }.to raise_error(ArgumentError, 'message')
     end
 
     it "fails if the block raises an exception of the same class and but doesn't include the string in its message" do
@@ -81,7 +81,7 @@ describe 'Matcher::RaiseError' do
         "matching #{'different'.inspect}"
 
       expect_failure(message) do
-        expect { raise ArgumentError.new('with a message') }.to raise_error(ArgumentError, 'different')
+        expect { fail ArgumentError.new('with a message') }.to raise_error(ArgumentError, 'different')
       end
     end
 
@@ -91,14 +91,14 @@ describe 'Matcher::RaiseError' do
         "matching #{'message'.inspect}"
 
       expect_failure(message) do
-        expect { raise ArgumentError.new('with a message') }.to raise_error(ZeroDivisionError, 'message')
+        expect { fail ArgumentError.new('with a message') }.to raise_error(ZeroDivisionError, 'message')
       end
     end
   end
 
   context 'with a class and regex arguements' do
     it 'passes if the block raises an exception of the same class and includes the string in its message' do
-      expect { raise ArgumentError.new('with a message') }.to raise_error(ArgumentError, /message/)
+      expect { fail ArgumentError.new('with a message') }.to raise_error(ArgumentError, /message/)
     end
 
     it "fails if the block raises an exception of the same class and but doesn't include the string in its message" do
@@ -107,7 +107,7 @@ describe 'Matcher::RaiseError' do
         "matching #{/different/.inspect}"
 
       expect_failure(message) do
-        expect { raise ArgumentError.new('with a message') }.to raise_error(ArgumentError, /different/)
+        expect { fail ArgumentError.new('with a message') }.to raise_error(ArgumentError, /different/)
       end
     end
 
@@ -117,7 +117,7 @@ describe 'Matcher::RaiseError' do
         " matching #{/message/.inspect} but was "
 
       expect_failure(message) do
-        expect { raise ArgumentError.new('with a message') }.to raise_error(ZeroDivisionError, /message/)
+        expect { fail ArgumentError.new('with a message') }.to raise_error(ZeroDivisionError, /message/)
       end
     end
   end

--- a/spec/motion-spec/mock_spec.rb
+++ b/spec/motion-spec/mock_spec.rb
@@ -1,0 +1,221 @@
+# -*- encoding : utf-8 -*-
+describe 'MotionSpec::Mock' do
+  # Test class for mocking.
+  class Dog
+    def self.create
+      new
+    end
+
+    def self.kind
+      'Mammal'
+    end
+
+    def bark
+      "Woof!"
+    end
+
+    def eat(food)
+      "#{food}! Yum!"
+    end
+
+    # Calls the given block on the nearest toy, a stuffed mouse.
+    def get_toy(&block)
+      block.call("stuffed mouse")
+    end
+
+    # Calls the given block on true (for a succesful fetch) and 2 (the time it
+    # took to fetch.
+    def fetch(&block)
+      block.call(true, 20)
+    end
+  end
+
+  before { @dog = Dog.new }
+
+  describe "#stub!" do
+    it "should stub a class method" do
+      Dog.stub!(:thing, return: :thing)
+      Dog.should.not.be.nil
+      Dog.thing.should == :thing
+    end
+
+    it "should stub an instance method" do
+      my_obj = Object.new
+      my_obj.stub!(:hello, return: "hi")
+      my_obj.hello.should.be == "hi"
+    end
+
+    it "should stub using block" do
+      my_obj = Object.new
+      my_obj.stub!(:hello) do |a, b|
+        a.should == "foo"
+        b.should == "bar"
+        "#{a},#{b}"
+      end
+      my_obj.hello("foo", "bar").should.be == "foo,bar"
+    end
+  end
+
+  describe "#stub" do
+    it "should create a pure stub" do
+      my_stub = stub(:thing, return: "dude, a thing!")
+      my_stub.thing.should == "dude, a thing!"
+    end
+
+    it "should create a stub using block" do
+      my_stub = stub(:thing) do |a, b|
+        a.should == "a"
+        b.should == "thing!"
+        "dude, #{a} #{b}"
+      end
+      my_stub.thing("a", "thing!").should == "dude, a thing!"
+    end
+  end
+
+  describe "#mock!" do
+    it "should mock an instance method on an object" do
+      @dog.mock!(:bark, return: "Meow!")
+      @dog.mock!(:eat, return: "Yuck!")
+      @dog.bark.should == "Meow!"
+      @dog.eat("broccoli").should == "Yuck!"
+    end
+
+    it "should mock using block" do
+      @dog.mock!(:bark) do |a|
+        a.should == "Meow!"
+        a
+      end
+      @dog.bark("Meow!").should == "Meow!"
+    end
+
+    it "should mock a class method" do
+      Dog.mock!(:create, return: "Dog")
+      Dog.create.should == "Dog"
+    end
+
+    it "should be able to yield a single object" do
+      @dog.mock!(:get_toy, yield: "stuffed fox")
+      @dog.get_toy do |toy|
+        toy.should.be == "stuffed fox"
+      end
+    end
+
+    it "should be able to yield multiple objects" do
+      @dog.mock!(:fetch, yield: [false, 10])
+      @dog.fetch do |success, time|
+        success.should.be == success
+        time.should.be == 10
+      end
+    end
+
+    it "should be able to yield the boolean value false" do
+      @dog.mock!(:get_toy, yield: false)
+      @dog.get_toy do |toy|
+        toy.should.be == false
+      end
+    end
+
+  end
+
+  describe "#mock" do
+    it "should create pure mock" do
+      my_mock = mock(:hello, return: "hi")
+      my_mock.hello.should == "hi"
+    end
+  end
+
+  describe "#should_not_call" do
+    it "should raise an error with an instance method" do
+      @dog.should_not_call(:bark)
+      should.raise(MotionSpec::Error) do
+        @dog.bark
+      end
+    end
+
+    it "should succeed if the call is not made" do
+      should.not.raise(MotionSpec::Error) do
+        @dog.should_not_call(:bark)
+      end
+    end
+
+    it "should not fail in another test" do
+      should.not.raise(MotionSpec::Error) do
+        @dog.bark
+      end
+    end
+
+    it "should raise an error with a class method" do
+      Dog.should_not_call(:create)
+      should.raise(MotionSpec::Error) do
+        Dog.create
+      end
+    end
+  end
+
+  describe "#reset" do
+    describe "stubbing" do
+      it "should restore original class method" do
+        Dog.stub!(:kind, return: 'Reptile')
+        Dog.kind.should == 'Reptile'
+        Dog.reset(:kind)
+        Dog.kind.should == 'Mammal'
+      end
+
+      it "should restore original instance method" do
+        @dog.stub!(:bark, return: 'Meow!')
+        @dog.bark.should == 'Meow!'
+        @dog.reset(:bark)
+        @dog.bark.should == 'Woof!'
+      end
+    end
+
+    describe "mocking" do
+      it "should restore original class method" do
+        Dog.mock!(:kind, return: 'Reptile')
+        Dog.kind.should == 'Reptile'
+        Dog.reset(:kind)
+        Dog.kind.should == 'Mammal'
+      end
+
+      it "should restore original instance method" do
+        @dog.mock!(:bark, return: 'Meow!')
+        @dog.bark.should == 'Meow!'
+        @dog.reset(:bark)
+        @dog.bark.should == 'Woof!'
+      end
+    end
+  end
+
+  describe "after each scenario" do
+    it "should verify mocks" do
+      MotionSpec::Should.class_eval do
+        def ignored_flunk(message)
+        end
+
+        alias_method :original_flunk, :flunk
+        alias_method :flunk, :ignored_flunk
+      end
+
+      Dog.mock!(:kind, return: 'Reptile')
+      1.should == 1
+    end
+
+    it "should have cleared mocks from the previous scenario" do
+      1.should == 1
+
+      MotionSpec::Should.class_eval { alias_method :flunk, :original_flunk }
+    end
+
+    describe "clear stubs" do
+      context "with stub" do
+        before { Dog.stub!(:kind, return: 'Foo') }
+
+        it { Dog.kind.should == 'Foo' }
+      end
+
+      context "without stub" do
+        it { Dog.kind.should == 'Mammal' }
+      end
+    end
+  end
+end

--- a/spec/motion-spec/mock_spec.rb
+++ b/spec/motion-spec/mock_spec.rb
@@ -11,7 +11,7 @@ describe 'MotionSpec::Mock' do
     end
 
     def bark
-      "Woof!"
+      'Woof!'
     end
 
     def eat(food)
@@ -20,7 +20,7 @@ describe 'MotionSpec::Mock' do
 
     # Calls the given block on the nearest toy, a stuffed mouse.
     def get_toy(&block)
-      block.call("stuffed mouse")
+      block.call('stuffed mouse')
     end
 
     # Calls the given block on true (for a succesful fetch) and 2 (the time it
@@ -32,119 +32,118 @@ describe 'MotionSpec::Mock' do
 
   before { @dog = Dog.new }
 
-  describe "#stub!" do
-    it "should stub a class method" do
+  describe '#stub!' do
+    it 'should stub a class method' do
       Dog.stub!(:thing, return: :thing)
       Dog.should.not.be.nil
-      Dog.thing.should == :thing
+      Dog.thing.should.eq :thing
     end
 
-    it "should stub an instance method" do
+    it 'should stub an instance method' do
       my_obj = Object.new
-      my_obj.stub!(:hello, return: "hi")
-      my_obj.hello.should.be == "hi"
+      my_obj.stub!(:hello, return: 'hi')
+      my_obj.hello.should.be.eq 'hi'
     end
 
-    it "should stub using block" do
+    it 'should stub using block' do
       my_obj = Object.new
       my_obj.stub!(:hello) do |a, b|
-        a.should == "foo"
-        b.should == "bar"
+        a.should.eq 'foo'
+        b.should.eq 'bar'
         "#{a},#{b}"
       end
-      my_obj.hello("foo", "bar").should.be == "foo,bar"
+      my_obj.hello('foo', 'bar').should.be.eq 'foo,bar'
     end
   end
 
-  describe "#stub" do
-    it "should create a pure stub" do
-      my_stub = stub(:thing, return: "dude, a thing!")
-      my_stub.thing.should == "dude, a thing!"
+  describe '#stub' do
+    it 'should create a pure stub' do
+      my_stub = stub(:thing, return: 'dude, a thing!')
+      my_stub.thing.should.eq 'dude, a thing!'
     end
 
-    it "should create a stub using block" do
+    it 'should create a stub using block' do
       my_stub = stub(:thing) do |a, b|
-        a.should == "a"
-        b.should == "thing!"
+        a.should.eq 'a'
+        b.should.eq 'thing!'
         "dude, #{a} #{b}"
       end
-      my_stub.thing("a", "thing!").should == "dude, a thing!"
+      my_stub.thing('a', 'thing!').should.eq 'dude, a thing!'
     end
   end
 
-  describe "#mock!" do
-    it "should mock an instance method on an object" do
-      @dog.mock!(:bark, return: "Meow!")
-      @dog.mock!(:eat, return: "Yuck!")
-      @dog.bark.should == "Meow!"
-      @dog.eat("broccoli").should == "Yuck!"
+  describe '#mock!' do
+    it 'should mock an instance method on an object' do
+      @dog.mock!(:bark, return: 'Meow!')
+      @dog.mock!(:eat, return: 'Yuck!')
+      @dog.bark.should.eq 'Meow!'
+      @dog.eat('broccoli').should.eq 'Yuck!'
     end
 
-    it "should mock using block" do
+    it 'should mock using block' do
       @dog.mock!(:bark) do |a|
-        a.should == "Meow!"
+        a.should.eq 'Meow!'
         a
       end
-      @dog.bark("Meow!").should == "Meow!"
+      @dog.bark('Meow!').should.eq 'Meow!'
     end
 
-    it "should mock a class method" do
-      Dog.mock!(:create, return: "Dog")
-      Dog.create.should == "Dog"
+    it 'should mock a class method' do
+      Dog.mock!(:create, return: 'Dog')
+      Dog.create.should.eq 'Dog'
     end
 
-    it "should be able to yield a single object" do
-      @dog.mock!(:get_toy, yield: "stuffed fox")
+    it 'should be able to yield a single object' do
+      @dog.mock!(:get_toy, yield: 'stuffed fox')
       @dog.get_toy do |toy|
-        toy.should.be == "stuffed fox"
+        toy.should.be.eq 'stuffed fox'
       end
     end
 
-    it "should be able to yield multiple objects" do
+    it 'should be able to yield multiple objects' do
       @dog.mock!(:fetch, yield: [false, 10])
       @dog.fetch do |success, time|
-        success.should.be == success
-        time.should.be == 10
+        success.should.be.eq success
+        time.should.be.eq 10
       end
     end
 
-    it "should be able to yield the boolean value false" do
+    it 'should be able to yield the boolean value false' do
       @dog.mock!(:get_toy, yield: false)
       @dog.get_toy do |toy|
-        toy.should.be == false
+        toy.should.be.eq false
       end
     end
-
   end
 
-  describe "#mock" do
-    it "should create pure mock" do
-      my_mock = mock(:hello, return: "hi")
-      my_mock.hello.should == "hi"
+  describe '#mock' do
+    it 'should create pure mock' do
+      my_mock = mock(:hello, return: 'hi')
+      my_mock.hello.should.eq 'hi'
     end
   end
 
-  describe "#should_not_call" do
-    it "should raise an error with an instance method" do
+  describe '#should_not_call' do
+    it 'should raise an error with an instance method' do
       @dog.should_not_call(:bark)
       should.raise(MotionSpec::Error) do
         @dog.bark
       end
     end
 
-    it "should succeed if the call is not made" do
+    it 'should succeed if the call is not made' do
       should.not.raise(MotionSpec::Error) do
         @dog.should_not_call(:bark)
       end
     end
 
-    it "should not fail in another test" do
+    it 'should not fail in another test' do
       should.not.raise(MotionSpec::Error) do
         @dog.bark
       end
     end
 
-    it "should raise an error with a class method" do
+    it 'should raise an error with a class method' do
       Dog.should_not_call(:create)
       should.raise(MotionSpec::Error) do
         Dog.create
@@ -152,44 +151,44 @@ describe 'MotionSpec::Mock' do
     end
   end
 
-  describe "#reset" do
-    describe "stubbing" do
-      it "should restore original class method" do
+  describe '#reset' do
+    describe 'stubbing' do
+      it 'should restore original class method' do
         Dog.stub!(:kind, return: 'Reptile')
-        Dog.kind.should == 'Reptile'
+        Dog.kind.should.eq 'Reptile'
         Dog.reset(:kind)
-        Dog.kind.should == 'Mammal'
+        Dog.kind.should.eq 'Mammal'
       end
 
-      it "should restore original instance method" do
+      it 'should restore original instance method' do
         @dog.stub!(:bark, return: 'Meow!')
-        @dog.bark.should == 'Meow!'
+        @dog.bark.should.eq 'Meow!'
         @dog.reset(:bark)
-        @dog.bark.should == 'Woof!'
+        @dog.bark.should.eq 'Woof!'
       end
     end
 
-    describe "mocking" do
-      it "should restore original class method" do
+    describe 'mocking' do
+      it 'should restore original class method' do
         Dog.mock!(:kind, return: 'Reptile')
-        Dog.kind.should == 'Reptile'
+        Dog.kind.should.eq 'Reptile'
         Dog.reset(:kind)
-        Dog.kind.should == 'Mammal'
+        Dog.kind.should.eq 'Mammal'
       end
 
-      it "should restore original instance method" do
+      it 'should restore original instance method' do
         @dog.mock!(:bark, return: 'Meow!')
-        @dog.bark.should == 'Meow!'
+        @dog.bark.should.eq 'Meow!'
         @dog.reset(:bark)
-        @dog.bark.should == 'Woof!'
+        @dog.bark.should.eq 'Woof!'
       end
     end
   end
 
-  describe "after each scenario" do
-    it "should verify mocks" do
+  describe 'after each scenario' do
+    it 'should verify mocks' do
       MotionSpec::Should.class_eval do
-        def ignored_flunk(message)
+        def ignored_flunk(_message)
         end
 
         alias_method :original_flunk, :flunk
@@ -197,24 +196,24 @@ describe 'MotionSpec::Mock' do
       end
 
       Dog.mock!(:kind, return: 'Reptile')
-      1.should == 1
+      1.should.eq 1
     end
 
-    it "should have cleared mocks from the previous scenario" do
-      1.should == 1
+    it 'should have cleared mocks from the previous scenario' do
+      1.should.eq 1
 
       MotionSpec::Should.class_eval { alias_method :flunk, :original_flunk }
     end
 
-    describe "clear stubs" do
-      context "with stub" do
+    describe 'clear stubs' do
+      context 'with stub' do
         before { Dog.stub!(:kind, return: 'Foo') }
 
-        it { Dog.kind.should == 'Foo' }
+        it { Dog.kind.should.eq 'Foo' }
       end
 
-      context "without stub" do
-        it { Dog.kind.should == 'Mammal' }
+      context 'without stub' do
+        it { Dog.kind.should.eq 'Mammal' }
       end
     end
   end

--- a/spec/motion-spec/should_spec.rb
+++ b/spec/motion-spec/should_spec.rb
@@ -20,14 +20,18 @@ describe MotionSpec::Should do
   end
 
   it 'has should.satisfy' do
+    # rubocop:disable Lint/UselessComparison
     proc { should.satisfy { 1 == 1 } }.should succeed
+    # rubocop:enable Lint/UselessComparison
     proc { should.satisfy { 1 } }.should succeed
 
+    # rubocop:disable Lint/UselessComparison
     proc { should.satisfy { 1 != 1 } }.should fail
+    # rubocop:enable Lint/UselessComparison
     proc { should.satisfy { false } }.should fail
 
-    proc { 1.should.satisfy { |n| n % 2 == 0 } }.should fail
-    proc { 2.should.satisfy { |n| n % 2 == 0 } }.should succeed
+    proc { 1.should.satisfy(&:even?) }.should fail
+    proc { 2.should.satisfy(&:even?) }.should succeed
   end
 
   it 'has should.equal' do
@@ -40,9 +44,10 @@ describe MotionSpec::Should do
     proc { '1'.should.equal 1 }.should fail
   end
 
+  # rubocop:disable Style/SignalException
   it 'has should.raise' do
     proc { proc { raise 'Error' }.should.raise }.should succeed
-    proc { proc { raise 'Error' }.should.raise RuntimeError }.should succeed
+    proc { proc { raise 'Error' }.should.raise(RuntimeError) }.should succeed
     proc { proc { raise 'Error' }.should.not.raise }.should fail
     proc { proc { raise 'Error' }.should.not.raise(RuntimeError) }.should fail
 
@@ -65,6 +70,7 @@ describe MotionSpec::Should do
     ex.should.be.kind_of RuntimeError
     ex.message.should =~ /foo/
   end
+  # rubocop:enable Style/SignalException
 
   it 'has should.be.an.instance_of' do
     proc { 'string'.should.be.instance_of String }.should succeed
@@ -114,25 +120,29 @@ describe MotionSpec::Should do
     proc do
       proc do
         proc do
-          Kernel.raise ZeroDivisionError.new('ArgumentError')
+          Kernel.fail ZeroDivisionError.new('ArgumentError')
         end.should.not.raise(RuntimeError, Comparable)
       end.should.raise ZeroDivisionError
     end.should succeed
 
+    # rubocop:disable Style/SignalException
     proc { proc { raise 'Error' }.should.not.raise }.should fail
+    # rubocop:enable Style/SignalException
   end
 
   it 'has should.throw' do
     proc { proc { throw :foo }.should.throw(:foo) }.should succeed
-    proc { proc {       :foo }.should.throw(:foo) }.should fail
+    proc { proc { :foo }.should.throw(:foo) }.should fail
 
     should.throw(:foo) { throw :foo }
   end
 
+  # rubocop:disable Lint/UselessComparison
   it 'has should.not.satisfy' do
     proc { should.not.satisfy { 1 == 2 } }.should succeed
     proc { should.not.satisfy { 1 == 1 } }.should fail
   end
+  # rubocop:enable Lint/UselessComparison
 
   it 'has should.not.equal' do
     proc { 'string1'.should.not.eq 'string2' }.should succeed
@@ -253,6 +263,7 @@ describe "#should shortcut for #it('should')" do
     @called.should.eq true
   end
 
+  # rubocop:disable Lint/UselessComparison
   should 'save some characters by typing should' do
     proc { should.satisfy { 1 == 1 } }.should.not.raise
   end
@@ -264,6 +275,7 @@ describe "#should shortcut for #it('should')" do
   should 'work nested' do
     should.satisfy { 1 == 1 }
   end
+  # rubocop:enable Lint/UselessComparison
 
   # before { @count = MotionSpec::Counter[:specifications] }
   # should 'add new specifications' do


### PR DESCRIPTION
Mocking/stumping methods to allow for testing in isolation. Not 100% how I want it implemented in the end (would rather just have stubbing and a matcher), but easy enough to get started.

Current:

``` ruby
describe "a stubbed string" do
  let(:string) { "a string" }
  before { string.stub!(:length).and_return(500) }

  it { expect(string.length).to eq(500) }
  it { expect(string.reverse).to eq("gnirts a") } # This will be happy
end

describe "a mocked string" do
  let(:string) { "a string" }
  before { string.mock!(:length).and_return(500) }

  it { expect(string.length).to eq(500) }
  it { expect(string.reverse).to eq("gnirts a") } # This will fail
end
```

Goal:

``` ruby
describe "a stubbed string" do
  let(:string) { "a string" }
  before { allow(string).to receive(:length).and_return(500) }

  it { expect(string.length).to eq(500) }
  it { expect(string.reverse).to eq("gnirts a") }
  it { expect(string).to receive(:length); string.length }
end
```
